### PR TITLE
fix issues with editing index.

### DIFF
--- a/src/tags_edit.cpp
+++ b/src/tags_edit.cpp
@@ -337,7 +337,7 @@ struct TagsEdit::Impl {
 
     void editNewTag(size_t i) {
         tags.insert(std::next(begin(tags), static_cast<std::ptrdiff_t>(i)), Tag());
-        if (editing_index >= i) {
+        if (editing_index <= i) {
             ++editing_index;
         }
         setEditingIndex(i);
@@ -781,7 +781,7 @@ void TagsEdit::tags(std::vector<QString> const& tags) {
                        return Tag{text, QRect(), 0};
                    });
     impl->tags = std::move(t);
-    impl->editNewTag(impl->tags.size());
+    impl->editing_index = impl->tags.size() - 1;
     impl->updateDisplayText();
     impl->calcRectsAndUpdateScrollRanges();
     viewport()->update();


### PR DESCRIPTION
1. fix wrong direction of comparison
2. fix setting up new index when replacing the tags. Fixes out of
 bounds accesses and erasures when the new tags are fewer than the
 previous ones and reduces superfluous operations by setting the
 index directly